### PR TITLE
Update CMakeLists.txt: recursive checkout of jedi-cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ set( ENABLE_MPI ON CACHE BOOL "Compile with MPI")
 
 # Initialize
 ecbuild_bundle_initialize()
-ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" BRANCH develop UPDATE )
+ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" BRANCH develop UPDATE RECURSIVE )
 include( jedicmake/cmake/Functions/git_functions.cmake  )
 
 # ECMWF libs


### PR DESCRIPTION
## Description

Add `RECURSIVE` checkout option to `jedi-cmake` in bundle.

### Issue(s) addressed

Required for https://github.com/JCSDA-internal/jedi-cmake/pull/27

## Acceptance Criteria (Definition of Done)

PR merged

## Dependencies

None

## Impact

None