### PR TITLE
Update ufs-weather-model to March 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,7 @@ ExternalProject_Add(ufs-weather-model
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
   GIT_REPOSITORY https://github.com/climbfuji/ufs-weather-model
   GIT_SUBMODULES_RECURSE TRUE
-  GIT_TAG feature/consolidate_dom_update_20230306  # updated from develop on Mar 6
-  #GIT_TAG feature/consolidate_dom_update_20230117  # updated from develop on Jan 17
+  GIT_TAG feature/consolidate_dom_update_20221114  # updated from develop on Mar 6
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
   UPDATE_DISCONNECTED ON
   INSTALL_DIR ${DEPEND_LIB_ROOT}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,8 @@ ExternalProject_Add(ufs-weather-model
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
   GIT_REPOSITORY https://github.com/climbfuji/ufs-weather-model
   GIT_SUBMODULES_RECURSE TRUE
-  GIT_TAG feature/consolidate_dom_update_20230117  # updated from develop on Jan 17
+  GIT_TAG feature/consolidate_dom_update_20230306  # updated from develop on Mar 6
+  #GIT_TAG feature/consolidate_dom_update_20230117  # updated from develop on Jan 17
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
   UPDATE_DISCONNECTED ON
   INSTALL_DIR ${DEPEND_LIB_ROOT}


### PR DESCRIPTION
## Description

Update ufs-weather-model to version of March 6.

This also requires updates to `fv3-jedi` and `fv3-jedi-data`, PRs are listed below in the "Dependencies" section. With those updates, the UFS c48 warmstart forecast and model runs (ctests) run to completion on my macOS for the new start date 20220215T06Z.

## Definition of Done

What does it mean for this issue to be done?  Is there a specific, measurable, milestone?

### Issue(s) addressed

n/a

## Dependencies

- Waiting on https://github.com/JCSDA-internal/fv3-jedi-data/pull/64
- Waiting on https://github.com/JCSDA-internal/fv3-jedi/pull/809
 
## Impact

None (since updates to JEDI repos go into `feature/ufs_dom` branches).
