### PR TITLE
Update README.md for macOS ecbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ ecbuild --build=debug -DUFS_APP=ATMAERO .. 2>&1 | tee log.ecbuild
 ecbuild --build=debug -DUFS_APP=NG-GODAS .. 2>&1 | tee log.ecbuild
 ecbuild --build=debug -DUFS_APP=S2S .. 2>&1 | tee log.ecbuild
 ```
-On macOS, it may be required to pass `-DCMAKE_EXE_LINKER_FLAGS="-Wl,-no_compact_unwind"` to the ecbuild command,. Further, if using the native Apple `clang` compiler with `llvm-openmp` installed via homebrew or spack, it may be necessary to add `-DCMAKE_SHARED_LINKER_FLAGS="/path/to/llvm-openmp-x.y.z/lib/libomp.dylib"` to the ecbuild command.
+When using the native Apple `clang` compiler on macOS with `llvm-openmp` installed via homebrew or spack, it may be necessary to add `-DCMAKE_SHARED_LINKER_FLAGS="/path/to/llvm-openmp-x.y.z/lib/libomp.dylib"` to the ecbuild command.
 
 While building with soca (NG-GODAS or S2S), there will be a long pause during configuration when `ecbuild` is downloading the input files for the test to be run.
 


### PR DESCRIPTION
## Description

Remove hint to use `-DCMAKE_EXE_LINKER_FLAGS=-Wl,-no_compact_unwind` on macOS from top-level README.md.