### PR TITLE
Remove `branch_checkout` logic and fix branch handling error in CI script

### DIFF
--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -112,6 +112,7 @@ jobs:
       - name: clone-build-bundle
         env:
           JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
+          UFS_BUNDLE_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         run: |
           # In run directory
           cd ${JEDI_ENV}
@@ -119,16 +120,16 @@ jobs:
           # Set environment
           source setup.sh
 
-          echo "Using branch ${{ inputs.ufs-bundle-branch || 'develop' }} for ufs-bundle"
+          echo "Using branch ${UFS_BUNDLE_BRANCH_NAME} for ufs-bundle"
           if [ -d ufs-bundle ] ; then
             echo "Update existing copy of ufs-bundle"
             cd ufs-bundle
             git remote update
-            git checkout origin/${{ inputs.ufs-bundle-branch || 'develop' }}
+            git checkout origin/${UFS_BUNDLE_BRANCH_NAME}
             cd ..
           else
             echo "Check out a fresh copy of ufs-bundle"
-            git clone -b ${{ inputs.ufs-bundle-branch || 'develop' }} https://github.com/jcsda/ufs-bundle
+            git clone -b ${UFS_BUNDLE_BRANCH_NAME} https://github.com/jcsda/ufs-bundle
           fi
 
           # UFS_APP=ATM

--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -9,11 +9,6 @@ on:
     # pull request to develop
     branches: [develop]
   workflow_dispatch:
-    inputs:
-      ufs-bundle-branch:
-        description: 'The ufs-bundle branch to use. Default is "develop"'
-        required: true
-        default: 'develop'
 
 defaults:
   run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,28 +174,19 @@ endif()
 # ioda, ufo and fv3-jedi test data
 #----------------------------------------
 
-# If IODA branch is being built set GIT_BRANCH_FUNC to IODA's current branch.
-# If a tagged version of IODA is being built set GIT_TAG_FUNC to ioda's current tag. In this case,
-# IODA test files will be download from UCAR DASH and ioda-data repo will not be cloned.
 # When LOCAL_PATH_JEDI_TESTFILES is set to the directory of IODA test files stored
 # in a local directory, ioda-data repo will not be cloned
-
-find_branch_name(REPO_DIR_NAME ioda)
-# When LOCAL_PATH_JEDI_TESTFILES is set to the directory of IODA test files stored
-# in a local directory, ioda-data repo will not be cloned
-if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED ${GIT_TAG_FUNC} )
+if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} )
   ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )
 endif()
 
 # same procedure for ufo-data
-find_branch_name(REPO_DIR_NAME ufo)
-if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED ${GIT_TAG_FUNC} )
+if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} )
   ecbuild_bundle( PROJECT ufo-data GIT "https://github.com/JCSDA-internal/ufo-data.git" BRANCH develop UPDATE )
 endif()
 
 # same procedure for fv3-jedi-data
-find_branch_name(REPO_DIR_NAME fv3-jedi)
-if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED ${GIT_TAG_FUNC} )
+if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} )
   # DH* 20230718 revert this to feature/ufs_dom once https://github.com/JCSDA-internal/fv3-jedi-data/pull/78 is merged
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom_update_ufswm_20230717 )
   # *DH 20230718

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,19 +187,11 @@ if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED ${GIT_TAG_FUNC} )
   ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )
 endif()
 
-# If IODA's current branch is available in ioda-data repo, that branch will be checked out
-branch_checkout (REPO_DIR_NAME ioda-data
-                 BRANCH ${GIT_BRANCH_FUNC} )
-
 # same procedure for ufo-data
 find_branch_name(REPO_DIR_NAME ufo)
 if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED ${GIT_TAG_FUNC} )
   ecbuild_bundle( PROJECT ufo-data GIT "https://github.com/JCSDA-internal/ufo-data.git" BRANCH develop UPDATE )
 endif()
-
-# If UFO's current branch is available in ufo-data repo, that branch will be checked out
-branch_checkout (REPO_DIR_NAME ufo-data
-                 BRANCH ${GIT_BRANCH_FUNC} )
 
 # same procedure for fv3-jedi-data
 find_branch_name(REPO_DIR_NAME fv3-jedi)
@@ -208,10 +200,6 @@ if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} AND NOT DEFINED ${GIT_TAG_FUNC} )
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom_update_ufswm_20230717 )
   # *DH 20230718
 endif()
-
-# If fv3-jedi's current branch is available in fv3-jedi-data repo, that branch will be checked out
-branch_checkout (REPO_DIR_NAME fv3-jedi-data
-                 BRANCH ${GIT_BRANCH_FUNC} )
 
 # Build Doxygen documentation
 # ---------------------------


### PR DESCRIPTION
## Description

1. Remove `branch_checkout` logic once and for all, because it breaks the CI tests and will continue to do so in the future.
2. Fix the definition of the branch, this now matches the Skylab CI logic and works as intended (I think!).

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

A cleaner and better build system with less things happening under the hood that the user doesn't want.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR: https://github.com/JCSDA/ufs-bundle/actions/runs/5618084763
