### PR TITLE
Switch CI to spack-stack-1.5.0

### DIFF
--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -89,7 +89,7 @@ jobs:
           module load stack-intel-oneapi-mpi/2021.6.0
           module load stack-python/3.10.8
 
-          module load jedi-ufs-env/unified-dev
+          module load jedi-ufs-env/1.0.0
 
           module li
 

--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -74,7 +74,7 @@ jobs:
           cat <<EOF > setup.sh
           #!/bin/bash
 
-          echo "Loading ufs-bundle environment using spack-stack-1.4.0"
+          echo "Loading ufs-bundle environment using spack-stack-1.5.0"
 
           ulimit -s unlimited
           ulimit -c unlimited
@@ -84,13 +84,12 @@ jobs:
 
           source /opt/intel/oneapi/compiler/2022.1.0/env/vars.sh
 
-          module use /mnt/experiments-efs/skylab-v5/spack-stack-1.4.0/envs/unified-env-v2/install/modulefiles/Core
+          module use /mnt/experiments-efs/skylab-v6/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
           module load stack-intel/2022.1.0
           module load stack-intel-oneapi-mpi/2021.6.0
           module load stack-python/3.10.8
 
           module load jedi-ufs-env/unified-dev
-          module unload crtm
 
           module li
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,7 @@ ExternalProject_Add(ufs-weather-model
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
   GIT_REPOSITORY https://github.com/climbfuji/ufs-weather-model
   GIT_SUBMODULES_RECURSE TRUE
-  # DH* 20230925 temporarily for testing
-  #GIT_TAG feature/consolidate_dom_update_20221114  # updated from develop on 2023/07/17
-  GIT_TAG feature/consolidate_dom_update_20221114_tmp_gocart_workaround_spst150
-  # *DH
+  GIT_TAG feature/consolidate_dom_update_20221114  # updated from develop on 2023/07/17
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
   UPDATE_DISCONNECTED ON
   INSTALL_DIR ${DEPEND_LIB_ROOT}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,10 @@ ExternalProject_Add(ufs-weather-model
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
   GIT_REPOSITORY https://github.com/climbfuji/ufs-weather-model
   GIT_SUBMODULES_RECURSE TRUE
-  GIT_TAG feature/consolidate_dom_update_20221114  # updated from develop on 2023/07/17
+  # DH* 20230925 temporarily for testing
+  #GIT_TAG feature/consolidate_dom_update_20221114  # updated from develop on 2023/07/17
+  GIT_TAG feature/consolidate_dom_update_20221114_tmp_gocart_workaround_spst150
+  # *DH
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
   UPDATE_DISCONNECTED ON
   INSTALL_DIR ${DEPEND_LIB_ROOT}


### PR DESCRIPTION
## Description

Update software stack to spack-stack-1.5.0. To fix a compilation problem for ATMAERO, I had to push a small change to the fv3-jedi branch feature/ufs_dom (https://github.com/JCSDA-internal/fv3-jedi/commit/288a9288124314d5cb21e297ee66f70ef5ba3dcd) - see https://github.com/GEOS-ESM/GOCART/pull/254 for more information.

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
