### PR TITLE
Update CMakeLists.txt for new data download logic, update fv3-jedi/fv3-jedi-data branches from develop

### DIFF
--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -130,7 +130,7 @@ jobs:
           cd ${JEDI_ENV}
           mkdir -p build-atm
           cd build-atm
-          ecbuild -DUFS_APP=ATM ../ufs-bundle
+          cmake -DUFS_APP=ATM ../ufs-bundle
           make update
           make -j8
 
@@ -147,7 +147,7 @@ jobs:
           cd ${JEDI_ENV}
           mkdir -p build-atmaero
           cd build-atmaero
-          ecbuild -DUFS_APP=ATMAERO ../ufs-bundle
+          cmake -DUFS_APP=ATMAERO ../ufs-bundle
           make update
           make -j8
 
@@ -156,7 +156,7 @@ jobs:
           #cd ${JEDI_ENV}
           #mkdir -p build-ng-godas
           #cd build-ng-godas
-          #ecbuild -DUFS_APP=NG-GODAS ../ufs-bundle
+          #cmake -DUFS_APP=NG-GODAS ../ufs-bundle
           #make update
           #make -j8
           #
@@ -164,7 +164,7 @@ jobs:
           #cd ${JEDI_ENV}
           #mkdir -p build-s2s
           #cd build-s2s
-          #ecbuild -DUFS_APP=S2S ../ufs-bundle
+          #cmake -DUFS_APP=S2S ../ufs-bundle
           #make update
           #make -j8
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,12 +28,7 @@ set( ENABLE_MPI ON CACHE BOOL "Compile with MPI")
 set( ENABLE_OMP ON CACHE BOOL "Compile with OpenMP")
 
 # Use external jedi-cmake or build in bundle
-if(DEFINED ENV{jedi_cmake_ROOT})
-  include( $ENV{jedi_cmake_ROOT}/share/jedicmake/Functions/git_functions.cmake )
-else()
-  ecbuild_bundle( PROJECT jedicmake GIT "https://github.com/jcsda-internal/jedi-cmake.git" TAG 1.4.0 UPDATE RECURSIVE )
-  include( jedicmake/cmake/Functions/git_functions.cmake )
-endif()
+include( $ENV{jedi_cmake_ROOT}/share/jedicmake/Functions/git_functions.cmake )
 
 # ECMWF libs
 # ----------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,8 @@ set_target_properties(mom6 PROPERTIES IMPORTED_LOCATION ${DEPEND_LIB_ROOT}/${CMA
 if(UFS_APP MATCHES "^(ATM)$" OR UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$")
   ecbuild_bundle( PROJECT femps         GIT "https://github.com/jcsda-internal/femps.git"         TAG 1.2.0 )
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
-  ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom_update_from_dev_20231020 UPDATE ) # updated from develop Oct 20 2023
-  ecbuild_bundle( PROJECT fv3-jedi      GIT "https://github.com/jcsda-internal/fv3-jedi.git"      BRANCH feature/ufs_dom_update_from_dev_20231020 UPDATE )  # updated from develop Oct 20 2023
+  ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom UPDATE ) # updated from develop Oct 20 2023
+  ecbuild_bundle( PROJECT fv3-jedi      GIT "https://github.com/jcsda-internal/fv3-jedi.git"      BRANCH feature/ufs_dom UPDATE )  # updated from develop Oct 20 2023
   if(UFS_APP MATCHES "^(S2S)$")
     ecbuild_bundle( PROJECT soca        GIT "https://github.com/jcsda-internal/soca.git"          BRANCH feature/ufs_dom UPDATE )  # note this has not been updated in a while, there are many merge conflicts that need to be resolved
     add_dependencies(soca ufs-weather-model)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,8 +57,13 @@ endif()
 
 ecbuild_bundle( PROJECT crtm GIT "https://github.com/JCSDA/CRTMv3.git" BRANCH develop UPDATE )
 
-ecbuild_bundle( PROJECT ioda  GIT "https://github.com/jcsda-internal/ioda.git" BRANCH develop UPDATE )
-ecbuild_bundle( PROJECT ufo   GIT "https://github.com/jcsda-internal/ufo.git" BRANCH develop UPDATE )
+option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
+ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )
+ecbuild_bundle( PROJECT ioda      GIT "https://github.com/jcsda-internal/ioda.git"      BRANCH develop UPDATE )
+
+option(ENABLE_UFO_DATA "Obtain ufo test data from ufo-data repository (vs tarball)" ON)
+ecbuild_bundle( PROJECT ufo-data GIT "https://github.com/jcsda-internal/ufo-data.git" BRANCH develop UPDATE )
+ecbuild_bundle( PROJECT ufo      GIT "https://github.com/jcsda-internal/ufo.git"      BRANCH develop UPDATE )
 
 # Options for building with certain models
 # ----------------------------------------
@@ -152,43 +157,20 @@ set_target_properties(fv3atm PROPERTIES IMPORTED_LOCATION ${DEPEND_LIB_ROOT}/${C
 set_target_properties(ccppphys PROPERTIES IMPORTED_LOCATION ${DEPEND_LIB_ROOT}/${CMAKE_INSTALL_LIBDIR}/libccpp_physics.a)
 set_target_properties(mom6 PROPERTIES IMPORTED_LOCATION ${DEPEND_LIB_ROOT}/${CMAKE_INSTALL_LIBDIR}/libmom6.a)
 
-if(UFS_APP MATCHES "^(S2S)$")
-  # fv3-jedi and associated repositories
-  # ------------------------------------
-  ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.git"    TAG 1.2.0 )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH feature/ufs_dom UPDATE )  # updated from develop Aug 30 2023
-  ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git"     BRANCH feature/ufs_dom UPDATE )  # note this has not been updated in a while, there are many merge conflicts that need to be resolved
-  add_dependencies(soca ufs-weather-model)
+if(UFS_APP MATCHES "^(ATM)$" OR UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$")
+  ecbuild_bundle( PROJECT femps         GIT "https://github.com/jcsda-internal/femps.git"         TAG 1.2.0 )
+  option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
+  ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom_update_from_dev_20231020 UPDATE ) # updated from develop Oct 20 2023
+  ecbuild_bundle( PROJECT fv3-jedi      GIT "https://github.com/jcsda-internal/fv3-jedi.git"      BRANCH feature/ufs_dom_update_from_dev_20231020 UPDATE )  # updated from develop Oct 20 2023
+  if(UFS_APP MATCHES "^(S2S)$")
+    ecbuild_bundle( PROJECT soca        GIT "https://github.com/jcsda-internal/soca.git"          BRANCH feature/ufs_dom UPDATE )  # note this has not been updated in a while, there are many merge conflicts that need to be resolved
+    add_dependencies(soca ufs-weather-model)
+  endif()
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
   ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom UPDATE )  # note this has not been updated in a while, there are many merge conflicts that need to be resolved
   add_dependencies(soca ufs-weather-model)
-elseif(UFS_APP MATCHES "^(ATM)$" OR UFS_APP MATCHES "^(ATMAERO)$")
-  ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.git"    TAG 1.2.0 )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH feature/ufs_dom UPDATE )  # updated from develop Aug 30 2023
 else()
   message(FATAL_ERROR "ufs-bundle unknown UFS_APP ${UFS_APP}")
-endif()
-
-
-# ioda, ufo and fv3-jedi test data
-#----------------------------------------
-
-# When LOCAL_PATH_JEDI_TESTFILES is set to the directory of IODA test files stored
-# in a local directory, ioda-data repo will not be cloned
-if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} )
-  ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )
-endif()
-
-# same procedure for ufo-data
-if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} )
-  ecbuild_bundle( PROJECT ufo-data GIT "https://github.com/JCSDA-internal/ufo-data.git" BRANCH develop UPDATE )
-endif()
-
-# same procedure for fv3-jedi-data
-if( NOT DEFINED ENV{LOCAL_PATH_JEDI_TESTFILES} )
-  # DH* 20230718 revert this to feature/ufs_dom once https://github.com/JCSDA-internal/fv3-jedi-data/pull/78 is merged
-  ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom_update_ufswm_20230717 ) # updated from develop Aug 30 2023
-  # *DH 20230718
 endif()
 
 # Build Doxygen documentation

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ The bundle can be built in three different configuragions: with fv3-jedi and the
 with soca and the UFS configured with a data-atmosphere using NG-GODAS, or with fv3-jedi and soca and the UFS
 configured with S2S coupling. Only the first two configurations have test cases and are known to work, but all will build.
 
-The parameter for specifying the configuration type is `-DAPP=[ATM|NG-GODAS|S2S]` on the ecbuild configuration line. Create a build directory under/outside `ufs-bundle` and `cd` to it. Then run one of the following `ecbuild` commands:
+The parameter for specifying the configuration type is `-DAPP=[ATM|NG-GODAS|S2S]` on the cmake configuration line. Create a build directory under/outside `ufs-bundle` and `cd` to it. Then run one of the following `cmake` commands:
 ```
-ecbuild --build=debug -DUFS_APP=ATM .. 2>&1 | tee log.ecbuild
-ecbuild --build=debug -DUFS_APP=ATMAERO .. 2>&1 | tee log.ecbuild
-ecbuild --build=debug -DUFS_APP=NG-GODAS .. 2>&1 | tee log.ecbuild
-ecbuild --build=debug -DUFS_APP=S2S .. 2>&1 | tee log.ecbuild
+cmake -DCMAKE_BUILD_TYPE=Debug -DUFS_APP=ATM .. 2>&1 | tee log.cmake
+cmake -DCMAKE_BUILD_TYPE=Debug -DUFS_APP=ATMAERO .. 2>&1 | tee log.cmake
+cmake -DCMAKE_BUILD_TYPE=Debug -DUFS_APP=NG-GODAS .. 2>&1 | tee log.cmake
+cmake -DCMAKE_BUILD_TYPE=Debug -DUFS_APP=S2S .. 2>&1 | tee log.cmake
 ```
-When using the native Apple `clang` compiler on macOS with `llvm-openmp` installed via homebrew or spack, it may be necessary to add `-DCMAKE_SHARED_LINKER_FLAGS="${llvm_openmp_ROOT}/lib/libomp.dylib"` to the ecbuild command.
+When using the native Apple `clang` compiler on macOS with `llvm-openmp` installed via homebrew or spack, it may be necessary to add `-DCMAKE_SHARED_LINKER_FLAGS="${llvm_openmp_ROOT}/lib/libomp.dylib"` to the `cmake` command.
 
 macOS users may also encounter this error during the linker phase:
 ```
@@ -86,7 +86,7 @@ install_name_tool -id ${parallelio_ROOT}/lib/libpiof.dylib ${parallelio_ROOT}/li
 install_name_tool -change libpioc.dylib ${parallelio_ROOT}/lib/libpioc.dylib ${parallelio_ROOT}/lib/libpiof.dylib
 ```
 
-While building with soca (NG-GODAS or S2S), there will be a long pause during configuration when `ecbuild` is downloading the input files for the test to be run.
+While building with soca (NG-GODAS or S2S), there will be a long pause during configuration when `cmake` is downloading the input files for the test to be run.
 
 After configuration, run `make -j 8` to build.
 
@@ -133,4 +133,4 @@ Errors while running CTest
 
 At this point, there are no ctests for ATMAERO or S2S.
 
-Note for later for running on Hera: need to add `-DMPIEXEC_EXECUTABLE="/apps/slurm/default/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"` to `ecbuild` command, then run `ctest -R get_` on login node, then acquire a compute node, for example via `salloc -N 1 -n 24 --time=480 --qos=batch -A da-cpu -I`, then run the actual `ctests` on the compute node.
+Note for later for running on Hera: need to add `-DMPIEXEC_EXECUTABLE="/apps/slurm/default/bin/srun" -DMPIEXEC_NUMPROC_FLAG="-n"` to `cmake` command, then run `ctest -R get_` on login node, then acquire a compute node, for example via `salloc -N 1 -n 24 --time=480 --qos=batch -A da-cpu -I`, then run the actual `ctests` on the compute node.


### PR DESCRIPTION
## Description

1. Update `CMakeLists.txt` for new data download logic
2. Update fv3-jedi/fv3-jedi-data branches from develop
3. Replace `ecbuild` command with `cmake` command everywhere
4. Simplify logic around `UFS_APP` choice

## Issue(s) addressed

Part of data download PRs

## Dependencies

https://github.com/JCSDA-internal/fv3-jedi/pull/1057
https://github.com/JCSDA-internal/fv3-jedi-data/pull/85

## Impact

n/a

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR: CI tests pass, also locally on my macOS
