### PR TITLE
Switch ufs-bundle CI to spack-stack-1.5.1

### DIFF
--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -74,7 +74,7 @@ jobs:
           cat <<EOF > setup.sh
           #!/bin/bash
 
-          echo "Loading ufs-bundle environment using spack-stack-1.5.0"
+          echo "Loading ufs-bundle environment using spack-stack-1.5.1"
 
           ulimit -s unlimited
           ulimit -c unlimited
@@ -84,7 +84,7 @@ jobs:
 
           source /opt/intel/oneapi/compiler/2022.1.0/env/vars.sh
 
-          module use /mnt/experiments-efs/skylab-v6/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core
+          module use /mnt/experiments-efs/skylab-v7/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
           module load stack-intel/2022.1.0
           module load stack-intel-oneapi-mpi/2021.6.0
           module load stack-python/3.10.8
@@ -183,8 +183,8 @@ jobs:
           message_format: '{emoji} *{workflow}* {status_message} for branch {branch} in <{repo_url}|{repo}>'
           footer: ${{ github.event.pull_request.number || github.event_name || 'workflow dispatched manually' }}
           # For testing: only notify user Dom
-          mention_users: 'U02NLGXF5HV'
-          mention_users_when: 'failure,warnings'
+          #mention_users: 'U02NLGXF5HV'
+          #mention_users_when: 'failure,warnings'
           ## Default: notify channel
-          #mention_groups: '!channel'
-          #mention_groups_when: 'failure,warnings'
+          mention_groups: '!channel'
+          mention_groups_when: 'failure,warnings'

--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -20,7 +20,9 @@ jobs:
 
     steps:
       - name: cleanup
-        if: ${{ github.event_name == 'schedule' }}
+        # DH* TO ALLOW FOR TESTING PARALLEL TO OTHER PRS
+        #if: ${{ github.event_name == 'schedule' }}
+        # *DH
         env:
           JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
         run: |
@@ -188,3 +190,16 @@ jobs:
           ## Default: notify channel
           mention_groups: '!channel'
           mention_groups_when: 'failure,warnings'
+
+      # DH* TO ALLOW FOR TESTING PARALLEL TO OTHER PRS
+      - name: cleanuponcemore
+        env:
+          JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
+        run: |
+          # Remove and prepare run directory
+          rm -fr ${JEDI_ENV}
+          mkdir -p ${JEDI_ENV}
+          cd ${JEDI_ENV}
+          pwd
+          ls -lart
+      # *DH

--- a/.github/workflows/run_ec2_pcluster.yaml
+++ b/.github/workflows/run_ec2_pcluster.yaml
@@ -20,9 +20,7 @@ jobs:
 
     steps:
       - name: cleanup
-        # DH* TO ALLOW FOR TESTING PARALLEL TO OTHER PRS
-        #if: ${{ github.event_name == 'schedule' }}
-        # *DH
+        if: ${{ github.event_name == 'schedule' }}
         env:
           JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
         run: |
@@ -190,16 +188,3 @@ jobs:
           ## Default: notify channel
           mention_groups: '!channel'
           mention_groups_when: 'failure,warnings'
-
-      # DH* TO ALLOW FOR TESTING PARALLEL TO OTHER PRS
-      - name: cleanuponcemore
-        env:
-          JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
-        run: |
-          # Remove and prepare run directory
-          rm -fr ${JEDI_ENV}
-          mkdir -p ${JEDI_ENV}
-          cd ${JEDI_ENV}
-          pwd
-          ls -lart
-      # *DH


### PR DESCRIPTION
## Description

Switch ufs-bundle CI to spack-stack-1.5.1 (will be required starting Tuesday Dec 12 because of ecmwf-atlas@0.35.0), and tag CI channel and not just Dom in case of failures (so that I am not the only one that gets bombarded by slack notification if ufs-bundle CI is broken).

## Issue(s) addressed

n/a

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR: see https://github.com/JCSDA/ufs-bundle/actions/runs/7142580827/job/19452166016?pr=46 (tests passed)
