### PR TITLE
Fix failing CI tests (CRTM cmake errors) and remove dependency on `w3nco`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if(UFS_APP MATCHES "^(ATM)$" OR UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES
   ecbuild_bundle( PROJECT femps         GIT "https://github.com/jcsda-internal/femps.git"         TAG 1.2.0 )
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom UPDATE )  # updated from develop Dec 05 2023
-  ecbuild_bundle( PROJECT fv3-jedi      GIT "https://github.com/jcsda-internal/fv3-jedi.git"      BRANCH feature/retire_w3nco UPDATE )  # updated from develop Dec 12 2023
+  ecbuild_bundle( PROJECT fv3-jedi      GIT "https://github.com/jcsda-internal/fv3-jedi.git"      BRANCH feature/ufs_dom UPDATE )  # updated from develop Dec 12 2023
   if(UFS_APP MATCHES "^(S2S)$")
     ecbuild_bundle( PROJECT soca        GIT "https://github.com/jcsda-internal/soca.git"          BRANCH feature/ufs_dom UPDATE )  # updated from develop Dec 12 2023
     add_dependencies(soca ufs-weather-model)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES
   ecbuild_bundle( PROJECT gsw GIT "https://github.com/jcsda-internal/GSW-Fortran.git" BRANCH develop UPDATE )
 endif()
 
-ecbuild_bundle( PROJECT crtm GIT "https://github.com/JCSDA/CRTMv3.git" BRANCH develop UPDATE )
+ecbuild_bundle( PROJECT crtm GIT "https://github.com/JCSDA/CRTMv3.git" BRANCH release/REL-3.1.0 UPDATE )
 
 option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
 ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,8 @@ if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES
   ecbuild_bundle( PROJECT gsw GIT "https://github.com/jcsda-internal/GSW-Fortran.git" BRANCH develop UPDATE )
 endif()
 
-ecbuild_bundle( PROJECT crtm GIT "https://github.com/JCSDA/CRTMv3.git" BRANCH release/REL-3.1.0 UPDATE )
+# Use last known working tag until issues with new pure cmake build are resolved
+ecbuild_bundle( PROJECT crtm GIT "https://github.com/JCSDA/CRTMv3.git" TAG v3.1.0-skylabv7 ) # BRANCH develop UPDATE )
 
 option(ENABLE_IODA_DATA "Obtain ioda test data from ioda-data repository (vs tarball)" ON)
 ecbuild_bundle( PROJECT ioda-data GIT "https://github.com/JCSDA-internal/ioda-data.git" BRANCH develop UPDATE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,7 +156,7 @@ if(UFS_APP MATCHES "^(ATM)$" OR UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES
   ecbuild_bundle( PROJECT femps         GIT "https://github.com/jcsda-internal/femps.git"         TAG 1.2.0 )
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH feature/ufs_dom UPDATE )  # updated from develop Dec 05 2023
-  ecbuild_bundle( PROJECT fv3-jedi      GIT "https://github.com/jcsda-internal/fv3-jedi.git"      BRANCH feature/ufs_dom UPDATE )  # updated from develop Dec 12 2023
+  ecbuild_bundle( PROJECT fv3-jedi      GIT "https://github.com/jcsda-internal/fv3-jedi.git"      BRANCH feature/retire_w3nco UPDATE )  # updated from develop Dec 12 2023
   if(UFS_APP MATCHES "^(S2S)$")
     ecbuild_bundle( PROJECT soca        GIT "https://github.com/jcsda-internal/soca.git"          BRANCH feature/ufs_dom UPDATE )  # updated from develop Dec 12 2023
     add_dependencies(soca ufs-weather-model)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Currently Loaded Modules:
  13) stack-python/3.10.8       34) nccmp/1.9.0.1            55) jedi-cmake/1.4.0   76) py-netcdf4/1.5.3             97) gftl-shared/1.5.0
  14) bacio/2.4.1               35) py-pip/23.0              56) libxt/1.1.5        77) py-bottleneck/1.3.5          98) yafyaml/0.5.1
  15) curl/8.0.1                36) wget/1.21.3              57) libxmu/1.1.2       78) py-packaging/23.0            99) mapl/2.35.2-esmf-8.4.2
- 16) pkg-config/0.29.2         37) base-env/1.0.0           58) libxpm/3.5.12      79) py-numexpr/2.8.3            100) w3nco/2.4.1
+ 16) pkg-config/0.29.2         37) base-env/1.0.0           58) libxpm/3.5.12      79) py-numexpr/2.8.3            100) w3emc/2.10.0
  17) hdf5/1.14.0               38) boost/1.78.0             59) libxaw/1.0.13      80) py-six/1.16.0               101) nemsio/2.5.2
  18) netcdf-c/4.9.2            39) bufr/12.0.0              60) udunits/2.2.28     81) py-python-dateutil/2.8.2    102) sigio/2.3.2
  19) netcdf-fortran/4.6.0      40) git-lfs/3.1.4            61) ncview/2.1.8       82) py-pytz/2022.2.1            103) w3emc/2.9.2


### PR DESCRIPTION
## Description

1. Use tag `v3.1.0-skylabv7` for CRTM until problems with recently introduced plain `cmake` build are resolved
2. Remove dependency on `w3nco` (replaced by `w3emc`); for more details see associated PR https://github.com/JCSDA-internal/fv3-jedi/pull/1127

Note. Once https://github.com/JCSDA-internal/fv3-jedi/pull/1127 is merged, need to revert the temporary branch name change for `fv3-jedi`

## Issue(s) addressed

Resolves failing CI tests

This is a workaround for https://github.com/JCSDA/ufs-bundle/issues/49 (not a solution)

## Dependencies

- [x] waiting on https://github.com/JCSDA-internal/fv3-jedi/pull/1127

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR: https://github.com/JCSDA/ufs-bundle/actions/runs/7675916463/job/20922782524?pr=48
