### PR TITLE
Move CI to c6a single node

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -92,6 +92,7 @@ jobs:
           module load stack-intel-oneapi-mpi/2021.10.0
           module load stack-python/3.10.13
           module load sp/2.5.0
+          module load awscli-v2
 
           module load jedi-ufs-env
           module load fms/2023.04

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -20,7 +20,8 @@ jobs:
 
     steps:
       - name: cleanup
-        if: ${{ github.event_name == 'schedule' }}
+        # DH* REVERT - DO CLEAN UP WITH NEXT PR NO MATTER WHAT
+        #if: ${{ github.event_name == 'schedule' }}
         env:
           JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
         run: |

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -20,8 +20,7 @@ jobs:
 
     steps:
       - name: cleanup
-        # DH* REVERT - DO CLEAN UP WITH NEXT PR NO MATTER WHAT
-        #if: ${{ github.event_name == 'schedule' }}
+        if: ${{ github.event_name == 'schedule' }}
         env:
           JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
         run: |

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   test-ufs-bundle:
-    runs-on: [self-hosted, Linux, X64, pcluster-ci-20230717]
+    runs-on: [ubuntu-ci-c6a-x86_64]
 
     steps:
       - name: cleanup
@@ -79,14 +79,17 @@ jobs:
           ulimit -s unlimited
           ulimit -c unlimited
 
-          source /etc/profile.d/z00_lmod.sh
-          source /etc/profile.d/z01_lmod.sh
+          source /etc/profile.d/modules.sh
 
-          source /opt/intel/oneapi/compiler/2022.1.0/env/vars.sh
+          source /opt/intel/oneapi/compiler/2023.2.3/env/vars.sh
+          source /opt/intel/oneapi/mpi/2021.10.0/env/vars.sh
 
-          module use /mnt/experiments-efs/skylab-v8/spack-stack-1.7.0-ci-c6i/envs/ue-intel-2021.6.0/install/modulefiles/Core
-          module load stack-intel/2021.6.0
-          module load stack-intel-oneapi-mpi/2021.6.0
+          module use /home/ubuntu/spack-stack/modulefiles
+          module load ecflow/5.11.4
+
+          module use /home/ubuntu/spack-stack/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core/
+          module load stack-intel/2021.10.0
+          module load stack-intel-oneapi-mpi/2021.10.0
           module load stack-python/3.10.13
           module load sp/2.5.0
 
@@ -95,13 +98,9 @@ jobs:
 
           module li
 
-          export I_MPI_DEBUG=5
-          export I_MPI_FABRICS=shm
-          export I_MPI_PIN_DOMAIN=omp
           export KMP_AFFINITY=compact
           export KMP_STACKSIZE=2048m
           export OMP_NUM_THREADS=1
-          export SLURM_EXPORT_ENV=ALL
 
           EOF
 
@@ -182,8 +181,8 @@ jobs:
           message_format: '{emoji} *{workflow}* {status_message} for branch {branch} in <{repo_url}|{repo}>'
           footer: ${{ github.event.pull_request.number || github.event_name || 'workflow dispatched manually' }}
           # For testing: only notify user Dom
-          #mention_users: 'U02NLGXF5HV'
-          #mention_users_when: 'failure,warnings'
+          mention_users: 'U02NLGXF5HV'
+          mention_users_when: 'failure,warnings'
           # Default: notify channel
-          mention_groups: '!channel'
-          mention_groups_when: 'failure,warnings'
+          # DH* TODO REVERT mention_groups: '!channel'
+          # DH* TODO REVERT mention_groups_when: 'failure,warnings'

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -182,8 +182,8 @@ jobs:
           message_format: '{emoji} *{workflow}* {status_message} for branch {branch} in <{repo_url}|{repo}>'
           footer: ${{ github.event.pull_request.number || github.event_name || 'workflow dispatched manually' }}
           # For testing: only notify user Dom
-          mention_users: 'U02NLGXF5HV'
-          mention_users_when: 'failure,warnings'
+          #mention_users: 'U02NLGXF5HV'
+          #mention_users_when: 'failure,warnings'
           # Default: notify channel
-          # DH* TODO REVERT mention_groups: '!channel'
-          # DH* TODO REVERT mention_groups_when: 'failure,warnings'
+          mention_groups: '!channel'
+          mention_groups_when: 'failure,warnings'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.gi
 if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES "^(ATM)$")
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH bugfix/setup_c48_envmod UPDATE ) #develop UPDATE )
+  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
   ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.gi
 if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES "^(ATM)$")
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
+  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH bugfix/setup_c48_envmod UPDATE ) #develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
   ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)


### PR DESCRIPTION
## Description

Rename `.github/workflows/run_ec2_pcluster.yaml` to `.github/workflows/ubuntu-c…i-x86_64.yaml` and update to run on AWS EC2 single node instance `c6a.8xlarge`. Since the latter uses tcl/tk environment modules instead of lua/lmod modules, an update is required for the setup script for the UFS c48 data in `fv3-jedi` so that it works for both tcl/tk and lua/lmod (tested in CI with tcl/tk, and on my macOS with lua/lmod).

Temporary branch name change for fv3-jedi needs to be reverted after https://github.com/JCSDA-internal/fv3-jedi/pull/1196 is merged.

## Issue(s) addressed

Last PRs needed to switch ufs-bundle CI runner to new instance.

## Dependencies

- [x] waiting on https://github.com/JCSDA-internal/fv3-jedi/pull/1196

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
