### PR TITLE
Set I_MPI_FABRICS and I_MPI_DEBUG in .github/workflows/ubuntu-ci-x86_64.yaml to fix hanging model runs

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -102,6 +102,8 @@ jobs:
           export KMP_AFFINITY=compact
           export KMP_STACKSIZE=2048m
           export OMP_NUM_THREADS=1
+          export I_MPI_FABRICS=shm
+          export I_MPI_DEBUG=5
 
           EOF
 


### PR DESCRIPTION
## Description

Set I_MPI_FABRICS and I_MPI_DEBUG in .github/workflows/ubuntu-ci-x86_64.yaml to fix hanging model runs

## Issue(s) addressed

Resolves CI failures (see e.g. https://github.com/JCSDA/ufs-bundle/actions/runs/9089817107)

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
