### PR TITLE
Update ubuntu-ci-x86_64.yaml - change spack-stack-1.7.0 location

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -87,7 +87,7 @@ jobs:
           module use /home/ubuntu/spack-stack/modulefiles
           module load ecflow/5.11.4
 
-          module use /home/ubuntu/spack-stack/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core/
+          module use /home/ubuntu/spack-stack-1.7.0/envs/ue-intel-2021.10.0/install/modulefiles/Core/
           module load stack-intel/2021.10.0
           module load stack-intel-oneapi-mpi/2021.10.0
           module load stack-python/3.10.13

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -50,18 +50,18 @@ jobs:
       #      docker run hello-world
       #    fi
       #
-      - name: set-credentials
-        env:
-          GH_USERNAME: ${{ secrets.JCSDABOT_USERNAME }}
-          GH_TOKEN: ${{ secrets.JCSDABOT_TOKEN }}
-        run: |
-          # git config and credentials
-          git config --global user.name "Luke Skywalker"
-          git config --global user.email "luke@skywalker.org"
-          git config --global credential.helper store
-          touch ~/.git-credentials
-          chmod 0700 ~/.git-credentials
-          echo "https://$GH_USERNAME:$GH_TOKEN@github.com" > ~/.git-credentials
+      #- name: set-credentials
+      #  env:
+      #    GH_USERNAME: ${{ secrets.JCSDABOT_USERNAME }}
+      #    GH_TOKEN: ${{ secrets.JCSDABOT_TOKEN }}
+      #  run: |
+      #    # git config and credentials
+      #    git config --global user.name "Luke Skywalker"
+      #    git config --global user.email "luke@skywalker.org"
+      #    git config --global credential.helper store
+      #    touch ~/.git-credentials
+      #    chmod 0700 ~/.git-credentials
+      #    echo "https://$GH_USERNAME:$GH_TOKEN@github.com" > ~/.git-credentials
       # *DH
 
       - name: create-env-setup-script
@@ -107,7 +107,7 @@ jobs:
 
           EOF
 
-      - name: clone-build-bundle
+      - name: clone-bundle
         env:
           JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
           UFS_BUNDLE_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -129,10 +129,18 @@ jobs:
             echo "Check out a fresh copy of ufs-bundle"
             git clone -b ${UFS_BUNDLE_BRANCH_NAME} https://github.com/jcsda/ufs-bundle
           fi
+          ### DO WE REALLY NEED THIS ??? rm -fr build-*
 
-          # UFS_APP=ATM
+      - name: build-atm
+        env:
+          JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
+        run: |
+          # In run directory
           cd ${JEDI_ENV}
-          rm -rf build-*
+
+          # Set environment
+          source setup.sh
+
           mkdir -p build-atm
           cd build-atm
           cmake -DUFS_APP=ATM ../ufs-bundle
@@ -144,25 +152,48 @@ jobs:
           rm -rf fv3-jedi/test/Data/ModelRunDirs/UFS_warmstart_2/*
           ctest -V -R ufs_
 
-          # UFS_APP=ATMAERO
+      - name: build-atmaero
+        env:
+          JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
+        run: |
+          # In run directory
           cd ${JEDI_ENV}
+
+          # Set environment
+          source setup.sh
+
           mkdir -p build-atmaero
           cd build-atmaero
           cmake -DUFS_APP=ATMAERO ../ufs-bundle
           make update
           make -j8
 
-          # Skip those for now - linker errors because of static/dynamic library mix
-          UFS_APP=NG-GODAS
+      - name: build-ng-godas
+        env:
+          JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
+        run: |
+          # In run directory
           cd ${JEDI_ENV}
+
+          # Set environment
+          source setup.sh
+
           mkdir -p build-ng-godas
           cd build-ng-godas
           cmake -DUFS_APP=NG-GODAS ../ufs-bundle
           make update
           make -j8
-          #
-          # UFS_APP=S2S
+
+      - name: build-s2s
+        env:
+          JEDI_ENV: /home/ubuntu/ufs-bundle/jedi_run
+        run: |
+          # In run directory
           cd ${JEDI_ENV}
+
+          # Set environment
+          source setup.sh
+
           mkdir -p build-s2s
           cd build-s2s
           cmake -DUFS_APP=S2S ../ufs-bundle

--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -50,18 +50,18 @@ jobs:
       #      docker run hello-world
       #    fi
       #
-      #- name: set-credentials
-      #  env:
-      #    GH_USERNAME: ${{ secrets.JCSDABOT_USERNAME }}
-      #    GH_TOKEN: ${{ secrets.JCSDABOT_TOKEN }}
-      #  run: |
-      #    # git config and credentials
-      #    git config --global user.name "Luke Skywalker"
-      #    git config --global user.email "luke@skywalker.org"
-      #    git config --global credential.helper store
-      #    touch ~/.git-credentials
-      #    chmod 0700 ~/.git-credentials
-      #    echo "https://$GH_USERNAME:$GH_TOKEN@github.com" > ~/.git-credentials
+      - name: set-credentials
+        env:
+          GH_USERNAME: ${{ secrets.JCSDABOT_USERNAME }}
+          GH_TOKEN: ${{ secrets.JCSDABOT_TOKEN }}
+        run: |
+          # git config and credentials
+          git config --global user.name "Luke Skywalker"
+          git config --global user.email "luke@skywalker.org"
+          git config --global credential.helper store
+          touch ~/.git-credentials
+          chmod 0700 ~/.git-credentials
+          echo "https://$GH_USERNAME:$GH_TOKEN@github.com" > ~/.git-credentials
       # *DH
 
       - name: create-env-setup-script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.gi
 if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES "^(ATM)$")
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH bugfix/ufs_s2s_cdeps_dependency UPDATE ) # develop UPDATE )
+  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
   ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.gi
 if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES "^(ATM)$")
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH feature/yet_another_bugfix_for_fv3jedi_for_ufs ) # develop UPDATE )
+  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
   ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
   ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
-  ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update UPDATE )
+  ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update_update ) # feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)
 else()
   message(FATAL_ERROR "ufs-bundle unknown UFS_APP ${UFS_APP}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.gi
 if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES "^(ATM)$")
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
+  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH bugfix/ufs_s2s_cdeps_dependency UPDATE ) # develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
   ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update_update ) # feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
   ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
-  ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update_update ) # feature/ufs_dom_update UPDATE )
+  ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)
 else()
   message(FATAL_ERROR "ufs-bundle unknown UFS_APP ${UFS_APP}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.gi
 if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES "^(ATM)$")
   option(ENABLE_FV3_JEDI_DATA "Obtain fv3-jedi test data from fv3-jedi-data repository (vs tarball)" ON)
   ecbuild_bundle( PROJECT fv3-jedi-data GIT "https://github.com/JCSDA-internal/fv3-jedi-data.git" BRANCH develop UPDATE )
-  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH develop UPDATE )
+  ecbuild_bundle( PROJECT fv3-jedi GIT "https://github.com/jcsda-internal/fv3-jedi.git" BRANCH feature/yet_another_bugfix_for_fv3jedi_for_ufs ) # develop UPDATE )
 elseif(UFS_APP MATCHES "^(NG-GODAS)$")
   ecbuild_bundle( PROJECT soca     GIT "https://github.com/jcsda-internal/soca.git" BRANCH feature/ufs_dom_update UPDATE )
   add_dependencies(soca ufs-weather-model)


### PR DESCRIPTION
## Description

Change location of spack-stack install directory and split the ufs builds up by application to make it easier to see where it fails.

Note. Contains a temporary change of the soca branch - the corresponding soca PR https://github.com/JCSDA-internal/soca/pull/1048 needs to be merged first if CI testing is successful, then the temporary change in `CMakeLists.txt` in this PR needs to be reverted. Same for https://github.com/JCSDA-internal/fv3-jedi/pull/1226

## Issue(s) addressed

Resolves failing CI since rebuild of the Ubuntu CI self-hosted runner

## Dependencies

- [x] waiting on https://github.com/JCSDA-internal/soca/pull/1048
- [x] waiting on https://github.com/JCSDA-internal/fv3-jedi/pull/1226
- [x] waiting on https://github.com/JCSDA-internal/fv3-jedi/pull/1230

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR
