### PR TITLE
Fix fv3atm-fms linker issue after fms/2023.04 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,12 @@ link_directories(${DEPEND_LIB_ROOT}/${CMAKE_INSTALL_LIBDIR})
 # Set variables for UFS clone and build
 # Needed to get correct OpenMP link libraries on macOS
 set(UFS_CMAKE_EXE_LINKER_FLAGS "-L${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}")
+find_package(FMS 2023.04 REQUIRED COMPONENTS R4 R8)
+if (FV3_PRECISION MATCHES DOUBLE)
+  add_library(fms ALIAS FMS::fms_r8)
+elseif (FV3_PRECISION MATCHES SINGLE)
+  add_library(fms ALIAS FMS::fms_r4)
+endif()
 find_package(OpenMP REQUIRED)
 if(APPLE)
   set(UFS_CMAKE_EXE_LINKER_FLAGS "${UFS_CMAKE_EXE_LINKER_FLAGS} ${OpenMP_libomp_LIBRARY} ${OpenMP_libomp_LIBRARY}")
@@ -173,7 +179,8 @@ set_target_properties( fv3atm PROPERTIES IMPORTED_LOCATION ${DEPEND_LIB_ROOT}/${
 set_target_properties( ccppphys PROPERTIES IMPORTED_LOCATION ${DEPEND_LIB_ROOT}/${CMAKE_INSTALL_LIBDIR}/libccpp_physics.a )
 set_target_properties( mom6 PROPERTIES IMPORTED_LOCATION ${DEPEND_LIB_ROOT}/${CMAKE_INSTALL_LIBDIR}/libmom6.a )
 
-
+# Additional dependencies that we can't know about because ufs-weather-model is an external project 
+target_link_libraries( fv3atm INTERFACE fms )
 
 ecbuild_bundle( PROJECT femps    GIT "https://github.com/jcsda-internal/femps.git"    TAG 1.3.0 )
 if(UFS_APP MATCHES "^(ATMAERO)$" OR UFS_APP MATCHES "^(S2S)$" OR UFS_APP MATCHES "^(ATM)$")


### PR DESCRIPTION
## Description

I don't claim to fully understand why this is happening now if it didn't happen before, but nonetheless ... this seems to work (at least for `UFS_APP=ATM` in my manual testing, CI will tell!)

**UPDATE.** It compiles i.e. gets past the error, but now it complains about
```
FATAL from PE     0: fv_grid_tools(read_grid): file INPUT/grid_spec.nc does not exist
```
I am going to toss this back to EPIC and JCSDA to resolve. @mark-a-potts @fmahebert @shlyaeva 

## Issue(s) addressed

Resolves https://github.com/JCSDA/ufs-bundle/issues/69 if it eventually gets fixed

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have run the unit tests before creating the PR
