### PR TITLE
Update ubuntu-ci-x86_64.yaml: move jedi-run back to root filesystem

### DIFF
--- a/.github/workflows/ubuntu-ci-x86_64.yaml
+++ b/.github/workflows/ubuntu-ci-x86_64.yaml
@@ -15,7 +15,7 @@ defaults:
     shell: bash
 
 env:
-  JEDI_ENV: /mnt/addon/jedi-run/ufs-bundle
+  JEDI_ENV: /home/ubuntu/ufs-bundle/jedi-run
 
 jobs:
   test-ufs-bundle:


### PR DESCRIPTION
## Description

Ran out of disk space on `/mnt/addon`, while there is plenty of space available on the root filesystem (at the moment ... this is only a duct-tape solution until we finally increase the disk space to something more than always close to the limit).

## Issue(s) addressed

https://github.com/JCSDA/ufs-bundle/actions/runs/10363417834/job/28687005074

## Dependencies

n/a

## Impact

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have run the unit tests before creating the PR https://github.com/JCSDA/ufs-bundle/actions/runs/10369258662/job/28704609684?pr=72
